### PR TITLE
use correct info to log in to docker hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
       - v[0-9]+.*
 
 env:
-  REGISTRY_IMAGE: informalsystems/hermes
+  REGISTRY_IMAGE: astriaorg/hermes
 
 jobs:
   docker-build:
@@ -42,8 +42,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push by digest
         id: build
@@ -95,8 +95,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -112,7 +112,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image to GHCR


### PR DESCRIPTION
Docker builds were failing in CI because it was using unset envars.