### PR TITLE
feat: set trusting period in hermes configuration

### DIFF
--- a/crates/relayer/src/chain/astria/endpoint.rs
+++ b/crates/relayer/src/chain/astria/endpoint.rs
@@ -1428,14 +1428,9 @@ impl ChainEndpoint for AstriaEndpoint {
         use ibc_relayer_types::clients::ics07_tendermint::client_state::AllowUpdate;
 
         let ClientSettings::Tendermint(settings) = settings;
-
-        // two hour duration
-        // TODO what is this?
-        let two_hours = Duration::from_secs(2 * 60 * 60);
-        let unbonding_period = two_hours;
-        let trusting_period_default = 2 * unbonding_period / 3;
-        let trusting_period = settings.trusting_period.unwrap_or(trusting_period_default);
-
+        // This is a hack to set the trusting and unbonding periods.
+        let unbonding_period = self.config.trusting_period();
+        let trusting_period = 2 * unbonding_period / 3;
         let proof_specs = crate::chain::astria::proof_specs::proof_spec_with_prehash();
 
         Self::ClientState::new(

--- a/crates/relayer/src/chain/cosmos/config.rs
+++ b/crates/relayer/src/chain/cosmos/config.rs
@@ -108,7 +108,7 @@ pub struct CosmosSdkConfig {
 
     /// The trusting period specifies how long a validator set is trusted for
     /// (must be shorter than the chain's unbonding period).
-    #[serde(default, with = "humantime_serde")]
+    #[serde(default = "default::trusting_period", with = "humantime_serde")]
     pub trusting_period: Option<Duration>,
 
     /// The rate at which to refresh the client referencing this chain,

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -237,6 +237,10 @@ pub mod default {
         TrustThreshold::TWO_THIRDS
     }
 
+    pub fn trusting_period() -> Option<Duration> {
+        Some(Duration::from_secs(60 * 60 * 24)) // 1 day
+    }
+
     pub fn client_refresh_rate() -> RefreshRate {
         // Refresh the client three times per trusting period
         RefreshRate::new(1, 3)
@@ -660,6 +664,12 @@ pub enum ChainConfig {
 }
 
 impl ChainConfig {
+    pub fn trusting_period(&self) -> Duration {
+        match self {
+            Self::CosmosSdk(config) => config.trusting_period.unwrap_or_default(),
+            Self::Astria(config) => config.trusting_period.unwrap_or_default(),
+        }
+    }
     pub fn id(&self) -> &ChainId {
         match self {
             Self::CosmosSdk(config) => &config.id,


### PR DESCRIPTION
Hermes is currently setting the trusting period of an astria client to two hours. This PR adds `unbonding period` and `trusting period` setup with environment variable. `unbonding period` is set to 1day by default.