### PR TITLE
fix: configurable trusting period

### DIFF
--- a/crates/relayer/src/chain/astria/endpoint.rs
+++ b/crates/relayer/src/chain/astria/endpoint.rs
@@ -1456,13 +1456,9 @@ impl ChainEndpoint for AstriaEndpoint {
 
         let ClientSettings::Tendermint(settings) = settings;
 
-        // two hour duration
-        // TODO what is this?
-        let two_hours = Duration::from_secs(2 * 60 * 60);
-        let unbonding_period = two_hours;
-        let trusting_period_default = 2 * unbonding_period / 3;
-        let trusting_period = settings.trusting_period.unwrap_or(trusting_period_default);
-
+        let trusting_period = self.config.trusting_period();
+        // Note: Astria does not have an unbonding period, so we set it to 3/2 of the trusting period.
+        let unbonding_period = trusting_period * 3 / 2;
         let proof_specs = crate::chain::astria::proof_specs::proof_spec_with_prehash();
 
         Self::ClientState::new(

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -237,6 +237,10 @@ pub mod default {
         TrustThreshold::TWO_THIRDS
     }
 
+    pub fn trusting_period() -> Option<Duration> {
+        Some(Duration::from_secs(60 * 60 * 24)) // 1 day
+    }
+
     pub fn client_refresh_rate() -> RefreshRate {
         // Refresh the client three times per trusting period
         RefreshRate::new(1, 3)
@@ -685,6 +689,13 @@ impl ChainConfig {
         match self {
             Self::CosmosSdk(config) => config.max_block_time,
             Self::Astria(config) => config.max_block_time,
+        }
+    }
+
+    pub fn trusting_period(&self) -> Duration {
+        match self {
+            Self::CosmosSdk(config) => config.trusting_period.unwrap_or_default(),
+            Self::Astria(config) => config.trusting_period.unwrap_or_default(),
         }
     }
 


### PR DESCRIPTION
### Summary
Astria client currently configured with two hours trusting period by default. Hermes now consider `trusting period` environment variable on client creation. If unset, trusting period defaults to `1day`.

### Changes
* added trusting period as a config variable with a `1day` default.

### Testing
Tested manually against a cluster, querying the client state after creation.

Note: should be moved to settings configuration in the future.
closes #17 