### PR TITLE
fix: update `build_packet_proofs` to query at latest height minus one

### DIFF
--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -535,8 +535,13 @@ pub trait ChainEndpoint: Sized {
         port_id: PortId,
         channel_id: ChannelId,
         sequence: Sequence,
-        height: ICSHeight,
+        _height: ICSHeight,
     ) -> Result<Proofs, Error> {
+        let current_height = self.query_application_status()?.height;
+        let height = current_height
+            .decrement()
+            .expect("height is greater than 0");
+
         let (maybe_packet_proof, channel_proof) = match packet_type {
             PacketMsgType::Recv => {
                 let (_, maybe_packet_proof) = self.query_packet_commitment(


### PR DESCRIPTION
 update `build_packet_proofs` to query at latest height minus one.

querying latest height doesn't work as the proofs are verified against the app hash finalized at height+1, and if that block is not yet finalized (which is often the case) then proof verification fails.

this should fix the error:
>  could not determine the correct snapshot to open given the `\"height\"` header of the request: failed to create state snapshot from IBC height header


which is caused by querying `astria` at a height >10 in the past, as only the latest 10 state snapshots are stored.

this has been tested with the monorepo IBC smoke test.